### PR TITLE
Website improvements

### DIFF
--- a/docs/assets/main.sass
+++ b/docs/assets/main.sass
@@ -166,15 +166,6 @@ main
     height: 2.5em
     list-style-type: none
     vertical-align: middle
-    li ~ li::before
-      content: "chevron_right"
-      //noinspection CssNoGenericFontName
-      font-family: "Material Symbols Outlined"
-      font-size: 1.5em
-      margin-inline: 0.2em
-      vertical-align: middle
-      color: var(--breadcrumb-chevrons)
-      font-weight: bold
   a
     color: var(--fg)
     text-decoration: none
@@ -184,6 +175,12 @@ main
       color: var(--link-hover)
     &.current:not(:hover)
       color: var(--link)
+  .breadcrumbsArrow
+      font-size: 1.5em
+      margin-inline: 0.2em
+      vertical-align: middle
+      color: var(--breadcrumb-chevrons)
+          font-weight: bold
 
 @media screen and (prefers-color-scheme: dark)
   \:root

--- a/docs/assets/main.sass
+++ b/docs/assets/main.sass
@@ -108,9 +108,6 @@ nav
 .active
   color: var(--link)
   font-weight: bold
-  &::after
-    @extend .sr-only
-    content: " (Active)"
 
 .content
   grid-area: content

--- a/docs/assets/main.ts
+++ b/docs/assets/main.ts
@@ -2,11 +2,11 @@ for (const el of document.querySelectorAll(".toggle[aria-controls]")) {
     const controls = document.getElementById(el.getAttribute("aria-controls"));
     const initialState = controls.classList.contains("collapsed");
     el.classList.toggle("collapsed", initialState);
-    el.setAttribute("aria-checked", (!initialState).toString());
+    el.setAttribute("aria-expanded", (!initialState).toString());
 
     function toggle() {
         const collapsed = controls.classList.toggle("collapsed");
-        el.setAttribute("aria-checked", (!collapsed).toString());
+        el.setAttribute("aria-expanded", (!collapsed).toString());
     }
 
     el.addEventListener("click", toggle);

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -1,5 +1,5 @@
 ---
-title: "Minecraft Access Configuration"
+title: "Configuration"
 ---
 
 This page contains all the configuration that controls the features on-off and behavior.

--- a/docs/content/downloads.md
+++ b/docs/content/downloads.md
@@ -1,0 +1,18 @@
+---
+title: "Downloads"
+---
+
+Minecraft Access is available for Fabric or Neoforge on Windows, Linux and Mac.
+
+If you're on Windows, see the [Fabric setup guide]({{% relref "/setup/basic" %}}) (recommended) or the [Neoforge setup guide]({{% relref "/setup/advanced" %}}).
+
+If you're on MacOS, see the [MacOS setup guide]({{% relref "/setup/macos" %}})
+
+Note: Currently there is no setup guide for Linux
+
+Minecraft Access is also a part of the [Visually Impaired Access Mods modpack](https://modrinth.com/modpack/vi-access) available on Modrinth. See the [modpack setup guide]({{% relref "/setup/modpack" %}}).
+
+# Download Minecraft Access
+- [Download from Github](https://github.com/khanshoaib3/minecraft-access/releases/)
+- [Download from CurseForge](https://www.curseforge.com/minecraft/mc-mods/blind-accessibility)
+- [Download from Modrinth](https://modrinth.com/mod/minecraft-access)

--- a/docs/content/features.md
+++ b/docs/content/features.md
@@ -1,5 +1,5 @@
 ---
-title: "Minecraft Access Features"
+title: "Features"
 ---
 
 This page contains details for all the features that are currently in the mod.

--- a/docs/content/keybindings.md
+++ b/docs/content/keybindings.md
@@ -1,5 +1,5 @@
 ---
-title: "Minecraft Access Keybindings"
+title: "Keybindings"
 ---
 
 This page contains all the keybindings added by the mod.

--- a/docs/content/sounds.html
+++ b/docs/content/sounds.html
@@ -1,9 +1,9 @@
 ---
-title: "Sound Effects Used in the Minecraft Access Mod"
+title: "Sound Effects Overview"
 ---
 <html lang="en">
 <head>
-    <title>Sound Effects used in the Minecraft Access Mod</title>
+    <title>Sound Effects Overview</title>
     <!-- Style is mainly copied from -->
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table -->
     <style>

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -26,7 +26,7 @@
     {{ with resources.Get "logo.png" }}
         <img class="logo"
              src="{{ .RelPermalink }}"
-             alt="Minecraft Access logo. A retro games controller graphic over a blurred background of a snowy mountain village next to a spruce forrest.">
+             alt="Logo: A retro games controller over a blurred snowy mountain village next to a spruce forrest.">
     {{ end }}
     {{ if hugo.IsDevelopment }}
         <span class="pill warn" title="This is an unreleased development version of the site.">Development</span>
@@ -36,9 +36,10 @@
 <nav class="main-nav" aria-label="Site Navigation">
     {{ partial "nav.html" (dict "Section" (.Site.GetPage "/") "CurrentPage" .) }}
 </nav>
-<div class="content">
+<div class="content" tabindex="-1">
     <div class="content-inner">
         <main>
+            <!-- This part is useless for the current size of the website and is causing some weirdness with screen readers, so I'm commenting it out for now
             <nav class="breadcrumbs" aria-label="Breadcrumbs">
                 <ol>
                     {{ range (collections.Append .Page .Page.Ancestors.Reverse) }}
@@ -54,6 +55,7 @@
                     {{ end }}
                 </ol>
             </nav>
+        -->
             <h1>{{ .Page.Title }}</h1>
             {{ if .Page.Content }}
                 <p>

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -39,11 +39,15 @@
 <div class="content" tabindex="-1">
     <div class="content-inner">
         <main>
-            <!-- This part is useless for the current size of the website and is causing some weirdness with screen readers, so I'm commenting it out for now
             <nav class="breadcrumbs" aria-label="Breadcrumbs">
                 <ol>
                     {{ range (collections.Append .Page .Page.Ancestors.Reverse) }}
                         <li>
+                            {{ if not .IsHome }}
+                            <span class="breadcrumbsArrow">
+                                {{ partial "icon" (dict "Icon" "chevron_right" "Label" "right arrow") }}
+                            </span>
+                            {{ end }}
                             <a href="{{ .RelPermalink }}" class="{{ if eq . $.Page }}current{{ end }}">
                                 {{ if .IsHome }}
                                     {{ partial "icon" (dict "Icon" "home" "Label" "home") }}
@@ -55,7 +59,6 @@
                     {{ end }}
                 </ol>
             </nav>
-        -->
             <h1>{{ .Page.Title }}</h1>
             {{ if .Page.Content }}
                 <p>

--- a/docs/layouts/partials/icon.html
+++ b/docs/layouts/partials/icon.html
@@ -1,2 +1,2 @@
 <span class="icon material-symbols-{{ default "outlined" .Style }} {{ .Class }}"
-      aria-label="{{ .Label }}" aria-hidden="{{ default "false" .Hidden }}">{{ .Icon }}</span>
+      aria-label="{{ .Label }}" aria-hidden="{{ default "true" .Hidden }}">{{ .Icon }}</span>

--- a/docs/layouts/partials/nav.html
+++ b/docs/layouts/partials/nav.html
@@ -2,7 +2,7 @@
     {{ if .Section.IsHome }}
         <li>
             <div class="nav-link {{ if eq .Section .CurrentPage }}active{{ end }}">
-                <a href="{{ .Section.RelPermalink }}">{{ default .Section.Path .Section.LinkTitle }}</a>
+                <a href="{{ .Section.RelPermalink }}" aria-current="{{ eq .Section $.CurrentPage }}">{{ default .Section.Path .Section.LinkTitle }}</a>
             </div>
         </li>
     {{ end }}
@@ -10,16 +10,16 @@
         <li>
             {{ if and .IsSection (not .Content) }}
                 <span class="nav-link toggle no-content"
-                      role="checkbox"
+                      role="button"
                       tabindex="0"
-                      aria-checked="{{ .IsAncestor $.CurrentPage }}"
+                      aria-current="{{ .IsAncestor $.CurrentPage }}"
                       aria-controls="section-list-{{ md5 . }}">
                     <span class="title">{{ default .Path .LinkTitle }}</span>
                     {{ partial "icon" (dict "Icon" "keyboard_arrow_down" "Label" "Dropdown toggle") }}
                 </span>
             {{ else }}
                 <div class="nav-link">
-                    <a href="{{ .RelPermalink }}" class="{{ if eq . $.CurrentPage }}active{{ end }}">{{ default .Path .LinkTitle }}</a>
+                    <a href="{{ .RelPermalink }}" aria-current="{{ eq . $.CurrentPage }}" class="{{ if eq . $.CurrentPage }}active{{ end }}">{{ default .Path .LinkTitle }}</a>
                     {{ if .IsSection }}
                         <button class="toggle"
                                 role="checkbox"


### PR DESCRIPTION
- Made everything (including logo alt text) singleline
- Made every icon hidden from screen readers
- Made navigation sections use buttons and aria-expanded instead of checkboxes
- Replaced literally having text saying "Active" next to the current page with the aria-current attribute
- Commented out the breadcrumbs section because currently it's useless and it caused some issues with screen readers
- Fix the issue where the screen reader would freeze when tabbing from the last navigation item by making the content section div unfocusable
- Renamed every page to remove the unnecessary Minecraft Access prefix
- Added a basic download page